### PR TITLE
Corrects README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,15 @@
-# `shortrib.app` DNS Automation
+# `chuckdantonio.com` DNS Automation
 
-Creates the necessary GCP objects to manage DNS for `shortrib.app`
+Creates the necessary GCP objects to manage DNS for `chuckdantonio.com`
 
 Reuses code from [Hashicorp's example](https://github.com/hashicorp/vault-guides/tree/master/operations/gcp-kms-unseal).
 
 ## Using this Repository
 
-### Prepare a Service Account
-
-To prepare a service account to execute these templates, execute the following steps:
-
-1. Create a service account:
-
-    ```bash
-    gcloud iam service-accounts create terraform-dns-shortrib-app \
-        --display-name "shortrib.app DNS management account"
-
-    gcloud iam service-accounts list
-    ```
-
-    Set the `$SERVICE_ACCOUNT_EMAIL` variable to match its `email` value.
-
-    ```bash
-    SERVICE_ACCOUNT_EMAIL=$(gcloud iam service-accounts list \
-      --filter="displayName:shortrib.app DNS management account" \
-      --format 'value(email)')
-    ```
-
-3. Assign roles to enable the account to execute
-
-    ```bash
-    PROJECT_ID=$(gcloud config get-value project)
-
-    gcloud projects add-iam-policy-binding $PROJECT_ID \
-        --member serviceAccount:$SERVICE_ACCOUNT_EMAIL \
-        --role roles/dns.admin
-
-4. Create the service account key and output the file to the `secrets` directory. 
-
-    ```bash
-    gcloud iam service-accounts keys create ${SECRETS_DIR}/terraform-dns-shortrib-app.json \
-        --iam-account $SERVICE_ACCOUNT_EMAIL
-    ```
-
-### Prepare a bucket for remote state storage
-
-To maintain Terraform state across systems and users, we'll use GCP to store the remote state.
-
-1. Create the bucket
-
-```bash
-BUCKET=$(basename $(pwd))    # or whatever you fancy
-
-gsutil mb gs://${BUCKET}
-gsutil versioning set on gs://${BUCKET}
-```
-
-2. Enable access
-
-```bash
-gsutil iam ch serviceAccount:${SERVICE_ACCOUNT_EMAIL}:objectAdmin gs://${BUCKET}
-```
+To prepare to use this repository, create a service account and 
+bucket for Terraform remote state using the script `prepare-remote-state`
+The script's in the `bin` directory which `direnv` will put in your
+path if you let it.
 
 ### Check the variables
 


### PR DESCRIPTION
TL;DR
-----

Fixes README so it references the right domain and instructions

Details
-------

Updates the README that was copied from another repo. Now it
describes the repo correctly and gives the right instructions
for using the `prepare-remote-state` script.
